### PR TITLE
Define NFS mount options for shared folders

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,7 +41,7 @@ Vagrant.configure("2") do |config|
   if CONF.has_key?('synced_folders')
     CONF['synced_folders'].each { |target, source|
       if source
-        config.vm.synced_folder source, target, :nfs => CONF['nfs'], :linux__nfs_options => ['rw', 'no_subtree_check', 'all_squash','async'], :create => true
+        config.vm.synced_folder source, target, :nfs => CONF['nfs'], :linux__nfs_options => ['rw', 'no_subtree_check', 'all_squash','async'], mount_options: ["rw", "tcp", "nolock", "noacl", "async"], :create => true
       end
     }
 


### PR DESCRIPTION
On Ubuntu 16.04, the following error happens when using flysystem:

> file_put_contents(): Exclusive locks are not supported for this stream

This can be fixed with the **nolock** mount option as suggested in the issue here https://github.com/thephpleague/flysystem/issues/445.