### PR TITLE
Updated PHPManager EXTRA_CONFIGURE_ARGUMENTS variable

### DIFF
--- a/puppet/modules/custom/profiles/files/box/phpmanager/scripts/phpmanager
+++ b/puppet/modules/custom/profiles/files/box/phpmanager/scripts/phpmanager
@@ -59,8 +59,8 @@ usage() {
 	fi
 	echo " PHP Source directory:                $SOURCE"
 	echo " Target directory:                    $TARGET"
-	if [ ! -z "$CONFIGURE_ARGUMENTS" ] ; then
-	    echo " Additional ./configure arguments:    $CONFIGURE_ARGUMENTS"
+	if [ ! -z "$EXTRA_CONFIGURE_ARGUMENTS" ] ; then
+	    echo " Additional ./configure arguments:    $EXTRA_CONFIGURE_ARGUMENTS"
 	fi
 	exit 1
 }


### PR DESCRIPTION
I had to use the option for extra php arguments to install bcmath.  Looks like the usage listing is looking for a different variable than what is used when making the PHP version.  I updated it so it will show correctly.