### PR TITLE
#152: when creating a screen also provide a -S name for easy killing …

### DIFF
--- a/puppet/environments/box/modules/profiles/files/box/cli/scripts/Command/Share.php
+++ b/puppet/environments/box/modules/profiles/files/box/cli/scripts/Command/Share.php
@@ -50,6 +50,9 @@ EOF
         $this->www = $input->getOption('www');
         $this->site = $input->getArgument('site');
 
+        //first lets clear any existing ngrok screens
+        `screen -S ngrokShare -X quit`;
+
         $this->_check();
 
         //in order to share joomla.box there can't be a vhost override
@@ -128,8 +131,8 @@ EOF
             $ngrok_command = "ngrok http $this->site.test:80";
         }
 
-        //launch ngrok and create a new screen to keep the user on the foreground
-        `screen -d -m $ngrok_command`;
+        //launch ngrok and create a new screen (with screen name) to keep the user on the foreground
+        `screen -S ngrokShare -d -m $ngrok_command`;
 
         //wait for the api to return connection details
         do


### PR DESCRIPTION
This PR closes #152

## Testing instructions 

Emulate multiple `box share` windows by: 

1. Open one terminal `vagrant ssh` 

2. emulate the `box share` screen by: 

`screen -S ngrokShare ngrok http joomlabox:80` 

3. Open another teminal `vagrant ssh` 

4. Attempt to `box share` in the normal fashion. 

### Expected result
You should see the first terminal window close the current ngrok session. Or failing that no other ngrokShare windows when you type `screen -ls` 